### PR TITLE
Pin specific androidx.core:core-ktx to 1.6.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     // https://github.com/facebook/react-native/blob/0.61-stable/template/android/app/build.gradle#L192
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation "androidx.core:core-ktx:+"
+    implementation "androidx.core:core-ktx:1.6.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 


### PR DESCRIPTION
Hopefully will fix this build failure: https://stackoverflow.com/questions/69021225/resource-linking-fails-on-lstar/69039771#69039771